### PR TITLE
fixed grammar, typo in "notation of keys"

### DIFF
--- a/doc/en/object/general.md
+++ b/doc/en/object/general.md
@@ -83,8 +83,8 @@ removed and is therefore missing from the output.
 ### Notation of Keys
 
     var test = {
-        'case': 'I am a keyword so I must be notated as a string',
-        delete: 'I am a keyword too so me' // raises SyntaxError
+        'case': 'I am a keyword, so I must be notated as a string',
+        delete: 'I am a keyword, so me too' // raises SyntaxError
     };
 
 Object properties can be both notated as plain characters and as strings. Due to


### PR DESCRIPTION
["Use commas to separate independent clauses when they are joined by any of these seven coordinating conjunctions: and, but, for, or, nor, so, yet."](http://owl.english.purdue.edu/owl/resource/607/02/)

I also rearranged a couple of words.
