### PR TITLE
A little bug about the zh branch

### DIFF
--- a/doc/zh/object/hasownproperty.md
+++ b/doc/zh/object/hasownproperty.md
@@ -36,7 +36,7 @@ JavaScript **不会**保护 `hasOwnProperty` 被非法占用，因此如果一�
     foo.hasOwnProperty('bar'); // 总是返回 false
 
     // 使用其它对象的 hasOwnProperty，并将其上下为设置为foo
-    {}.hasOwnProperty.call(foo, 'bar'); // true
+    ({}).hasOwnProperty.call(foo, 'bar'); // true
 
 ###结论
 


### PR DESCRIPTION
{}.hasOwnProperty.call(foo, 'bar');
//It does not work on chrome, I change it to this:
({}).hasOwnProperty.call(foo, 'bar');
![JavaScript ](https://f.cloud.github.com/assets/2226207/355704/d9d6dd70-a0ea-11e2-8aa0-20e55b89381b.png)
