### PR TITLE
fixed thrown TypeErrors on mac, while scrolling over the top edge

### DIFF
--- a/site/javascript/garden.js
+++ b/site/javascript/garden.js
@@ -33,7 +33,7 @@ Sections.prototype = {
             articleID = this.names[this.names.length - 1].id;
 
         for(var i = 0, l = this.names.length; i < l; i++) {
-            if (this.names[i].offset > scroll) {
+            if (scroll > 0 && this.names[i].offset > scroll) {
                 articleID = this.names[i - 1].id;
                 break;
             }


### PR DESCRIPTION
Due to the mac specific possibility to scroll above the top viewport edges (this nice viewport pull effect), you get some negative scroll and offset values. This causes a call of this.names[-1] which throws a TypeError. So we just test for a positive scroll value to prevent this.
