### PR TITLE
* typo fixes for turkish translation.

### DIFF
--- a/doc/tr/object/forinloop.md
+++ b/doc/tr/object/forinloop.md
@@ -32,7 +32,7 @@ nesnesinin [`hasOwnProperty`](#object.hasownproperty) metodu ile yapılır.
 
 Doğru kullanım bu yeni versiyonda gösterildiği gibidir. `hasOwnProperty` kontrol
 edildiği için **sadece** `moo` yazacaktır. `hasOwnProperty` kullanılmaz ise ve
-`Object.protype` 'ın baz özellikleri değiştirilmişse, program bazı hatalara
+`Object.prototype` 'ın baz özellikleri değiştirilmişse, program bazı hatalara
 yatkın olabilir.
 
 Bunu yapan ve yaygın olarak kullanılan bir JavaScript sistemi [Prototype][1]

--- a/doc/tr/object/prototype.md
+++ b/doc/tr/object/prototype.md
@@ -63,7 +63,7 @@ nesneyi kullanmasıdır; bu nedenle, tüm `Bar` nesneleri **aynı** `value`
 Bir nesnenin özelliklerine erişildiğinde, JavaScript, istenen isimdeki özelliği
 bulana kadar prototip zincirinde **yukarı** doğru dolaşır.
 
-Zincirin en üstüne ulaştığında (yani `Object.protype`) ve hala istenen özelliği
+Zincirin en üstüne ulaştığında (yani `Object.prototype`) ve hala istenen özelliği
 bulamamışsa sonuç olarak [`undefined`](#core.undefined) verecektir.
 
 ### prototype özelliği
@@ -90,7 +90,7 @@ yapıldığında da prototip zinciri üzerindeki **tüm** özelliklere bakılaca
 
 ### Temel prototiplerin genişletilmesi
 
-Sıklıkla yapılan bir hata `Object.protype` 'ı veya diğer baz prototipleri 
+Sıklıkla yapılan bir hata `Object.prototype` 'ı veya diğer baz prototipleri 
 genişletmektir.
 
 Bu tekniğe [*monkey patching*][1] denir ve *kapsüllemeyi* bozar. Bu teknik


### PR DESCRIPTION
In Turkish translation, "protype" has written instead of "prototype". this patch fixes this issue.
