### PR TITLE
fixed typo

### DIFF
--- a/doc/en/function/closures.md
+++ b/doc/en/function/closures.md
@@ -97,7 +97,7 @@ above.
     }
 
 There's yet another way to accomplish this by using `.bind`, which can bind
-a `this` context and arguments to function. It behaves identially to the code
+a `this` context and arguments to function. It behaves identically to the code
 above
 
     for(var i = 0; i < 10; i++) {


### PR DESCRIPTION
Typo on line 100 of closures.md. 'Identically' spelled 'identially':

As seen on the website:

![screen shot 2014-05-22 at 10 27 10 am](https://cloud.githubusercontent.com/assets/5958090/3057457/63425c24-e1d6-11e3-85ab-fbf082260f4b.png)
