### PR TITLE
Update garden.css

### DIFF
--- a/site/style/garden.css
+++ b/site/style/garden.css
@@ -601,7 +601,7 @@ screen and (-webkit-min-device-pixel-ratio: 2) {
 	}
 	
 	#nav_main > ul > li {
-		width: 25%;
+		width: 100%;
 	}
 	
 	#nav_mobile {


### PR DESCRIPTION
Nav li's are broken on Chrome Canary - Mac OSX. Should be 100% width.

[Screenshot](http://i.imgur.com/AfRqDSv.png)
