### PR TITLE
fixed highlight bug & modified .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 /site/es
 /site/zhtw
 /site/it
+/site/hu
 *.md~
 *.src.md
 *.DS_store

--- a/site/javascript/garden.js
+++ b/site/javascript/garden.js
@@ -18,10 +18,10 @@ Sections.prototype = {
     },
 
     map: function() {
-        this.names = $('section [id]').map(function(idx, ele) {
+        this.names = $('section>[id]').map(function(idx, ele) {
             return {
                 id: this.id.replace('.intro', ''),
-                offset: $(this).offset().top - 20,
+                offset: $(this).offset().top - 100,
                 title: $(this).find(':header:first').html()
             };
 
@@ -33,7 +33,7 @@ Sections.prototype = {
             articleID = this.names[this.names.length - 1].id;
 
         for(var i = 0, l = this.names.length; i < l; i++) {
-            if (scroll > 0 && this.names[i].offset > scroll) {
+            if (scroll >= 0 && this.names[i].offset > scroll) {
                 articleID = this.names[i - 1].id;
                 break;
             }


### PR DESCRIPTION
1. Line 21 : Because the different output which is complied by the 'marked' of new version, the header tags in .html have 'id' attribute. It makes the selector $('section [id]') contain more elements than before, so that the highlight navigation will be error.
2. Line 24: Make the highlight switching of the navigation more readable.
3. Line 36: When initial the webpage  scroll == 0, the if statement will never be true, so the articleID is always the last article's id, not the first.

pls fix these and deploy to the gh-pages. :)
