### PR TITLE
improve example code for call.apply

### DIFF
--- a/doc/en/function/arguments.md
+++ b/doc/en/function/arguments.md
@@ -38,22 +38,36 @@ another.
         // do stuff here
     }
 
-Another trick is to use both `call` and `apply` together to create fast, unbound
-wrappers.
+Another trick is to use both `call` and `apply` together to turn methods - functions that use the
+value of `this` as well as their arguments - into normal functions which only use their arguments.
 
-    function Foo() {}
+    function Person(first, last) {
+      this.first = first;
+      this.last = last;
+    }
 
-    Foo.prototype.method = function(a, b, c) {
-        console.log(this, a, b, c);
+    Person.prototype.fullname = function(joiner, options) {
+      options = options || { order: "western" };
+      var first = options.order === "western" ? this.first : this.last;
+      var last =  options.order === "western" ? this.last  : this.first;
+      return first + (joiner || " ") + last;
     };
 
-    // Create an unbound version of "method" 
-    // It takes the parameters: this, arg1, arg2...argN
-    Foo.method = function() {
-
-        // Result: Foo.prototype.method.call(this, arg1, arg2... argN)
-        Function.call.apply(Foo.prototype.method, arguments);
+    // Create an unbound version of "fullname", usable on any object with 'first'
+    // and 'last' properties passed as the first argument. This wrapper will
+    // not need to change if fullname changes in number or order of arguments.
+    Person.fullname = function() {
+      // Result: Person.prototype.fullname.call(this, joiner, ..., argN);
+      return Function.call.apply(Person.prototype.fullname, arguments);
     };
+
+    var grace = new Person("Grace", "Hopper");
+
+    // 'Grace Hopper'
+    grace.fullname();
+
+    // 'Turing, Alan'
+    Person.fullname({ first: "Alan", last: "Turing" }, ", ", { order: "eastern" });
 
 
 ### Formal Parameters and Arguments Indices


### PR DESCRIPTION
- current code is really abstract and confusing due to 'foo' and 'bar'
- and doesn't return, which is confusing
- make concrete