### PR TITLE
Remove style attribute from mainNav after slide up, fixes #99

### DIFF
--- a/site/javascript/garden.js
+++ b/site/javascript/garden.js
@@ -184,7 +184,7 @@ Page.prototype = {
         
         $('#nav_main').click(function(){
             if(that.window.width() < 1000)
-                mainNav.slideUp(300);
+                mainNav.slideUp(300, function() {this.removeAttr('style');});
         });
     },
 


### PR DESCRIPTION
After showing/hiding the menu in mobile mode, switching to fullscreen leaves the mainNav hidden because jquery set style="display: none;" at the end of the slideUp() animation.  This clears the style so it displays again.