### PR TITLE
Correction in the text [pt-BR] forinloop.md

### DIFF
--- a/doc/ptbr/object/forinloop.md
+++ b/doc/ptbr/object/forinloop.md
@@ -31,7 +31,7 @@ Esta é única forma correta de usar. Devido ao uso de `hasOwnProperty`, o exemp
 
 Um framework largamente utilizado que estende o `Object.prototype` é [Prototype][1].
 Quando este framework é utilizado, laços `for in` que não utilizam 
-`hasOwnProperty` ficam protegidos contra erros.
+`hasOwnProperty` ficam desprotegidos contra erros.
 
 ### Conclusão
 


### PR DESCRIPTION
If the Famework extends the Object.prototype then need to filter before passing through an object, it means if not to use hasOwnProperty will be unprotected against errors. No?