### PR TITLE
Updated prototype sample output

### DIFF
--- a/doc/by/object/prototype.md
+++ b/doc/by/object/prototype.md
@@ -40,7 +40,7 @@ JavaScript гэта адзіная шырока выкарыстоўваемая
     // Выніковы ланцужок прататыпаў
     test [instance of Bar]
         Bar.prototype [instance of Foo]
-            { foo: 'Hello World' }
+            { foo: 'Hello World', value: 42 }
             Foo.prototype
                 { method: ... }
                 Object.prototype

--- a/doc/en/object/prototype.md
+++ b/doc/en/object/prototype.md
@@ -41,7 +41,7 @@ chains*.
     // The resulting prototype chain
     test [instance of Bar]
         Bar.prototype [instance of Foo]
-            { foo: 'Hello World' }
+            { foo: 'Hello World', value: 42 }
             Foo.prototype
                 { method: ... }
                 Object.prototype

--- a/doc/es/object/prototype.md
+++ b/doc/es/object/prototype.md
@@ -41,7 +41,7 @@ llamadas de *cadenas de prototipo* (*prototype chains*).
     // Resultado de cadena de prototipos (prototype chain)
     test [instance of Bar]
         Bar.prototype [instance of Foo] 
-            { foo: 'Hello World' }
+            { foo: 'Hello World', value: 42 }
             Foo.prototype
                 { method: ... }
                 Object.prototype

--- a/doc/fi/object/prototype.md
+++ b/doc/fi/object/prototype.md
@@ -31,7 +31,7 @@ Ensimmäinen suuri ero liittyy siihen, kuinka perintä toimii. JavaScriptissä s
     // Prototyyppiketju
     test [Bar-olio]
         Bar.prototype [Foo-olio] 
-            { foo: 'Terve maailma' }
+            { foo: 'Terve maailma', value: 42 }
             Foo.prototype
                 { method: ... }
                 Object.prototype

--- a/doc/fr/object/prototype.md
+++ b/doc/fr/object/prototype.md
@@ -33,7 +33,7 @@ La première différence majeure est que l'héritage en JavaScript utilise des *
     // La chaîne de prototypes qui en résulte
     test [instance of Bar]
         Bar.prototype [instance of Foo]
-            { foo: 'Hello World' }
+            { foo: 'Hello World', value: 42 }
             Foo.prototype
                 { method: ... }
                 Object.prototype

--- a/doc/hu/object/prototype.md
+++ b/doc/hu/object/prototype.md
@@ -40,7 +40,7 @@ használ.
     // A kapott prototípus lánc
     test [instance of Bar]
         Bar.prototype [instance of Foo]
-            { foo: 'Hello World' }
+            { foo: 'Hello World', value: 42 }
             Foo.prototype
                 { method: ... }
                 Object.prototype

--- a/doc/it/object/prototype.md
+++ b/doc/it/object/prototype.md
@@ -43,7 +43,7 @@ La prima grande differenza è che l'ereditarietà in JavaScript utilizza le
     // La catena di prototipi finale
     test [istanza di Bar]
         Bar.prototype [istanza di Foo]
-            { foo: 'Hello World' }
+            { foo: 'Hello World', value: 42 }
             Foo.prototype
                 { method: ... }
                 Object.prototype

--- a/doc/ja/object/prototype.md
+++ b/doc/ja/object/prototype.md
@@ -33,7 +33,7 @@ JavaScriptはプロトタイプベースが採用されている唯一の広範�
     // プロトタイプチェーンの結果
     test [instance of Bar]
         Bar.prototype [instance of Foo] 
-            { foo: 'Hello World' }
+            { foo: 'Hello World', value: 42 }
             Foo.prototype
                 { method: ... }
                 Object.prototype

--- a/doc/ko/object/prototype.md
+++ b/doc/ko/object/prototype.md
@@ -31,7 +31,7 @@ Javascript는 클래스 스타일의 상속 모델을 사용하지 않고 *프�
     // 결과적으로 만들어진 프로토타입 체인은 다음과 같다. 
     test [instance of Bar]
         Bar.prototype [instance of Foo] 
-            { foo: 'Hello World' }
+            { foo: 'Hello World', value: 42 }
             Foo.prototype
                 { method: ... }
                 Object.prototype

--- a/doc/pl/object/prototype.md
+++ b/doc/pl/object/prototype.md
@@ -41,7 +41,7 @@ tak zwanych *łańcuchów prototypów*.
     // The resulting prototype chain
     test [instance of Bar]
         Bar.prototype [instance of Foo] 
-            { foo: 'Hello World' }
+            { foo: 'Hello World', value: 42 }
             Foo.prototype
                 { method: ... }
                 Object.prototype

--- a/doc/ptbr/object/prototype.md
+++ b/doc/ptbr/object/prototype.md
@@ -37,7 +37,7 @@ A primeira grande diferença é que herança em JavaScript utiliza o conceito de
     // A cadeia prototype resultante
     test [instance of Bar]
         Bar.prototype [instance of Foo]
-            { foo: 'Hello World' }
+            { foo: 'Hello World', value: 42 }
             Foo.prototype
                 { method: ... }
                 Object.prototype

--- a/doc/ru/object/prototype.md
+++ b/doc/ru/object/prototype.md
@@ -31,7 +31,7 @@
     // Цепочка прототипов, которая получится в результате
     test [instance of Bar]
         Bar.prototype [instance of Foo]
-            { foo: 'Hello World' }
+            { foo: 'Hello World', value: 42 }
             Foo.prototype
                 { method: ... }
                 Object.prototype

--- a/doc/tr/object/prototype.md
+++ b/doc/tr/object/prototype.md
@@ -39,7 +39,7 @@ yapılmasıdır.
     // Sonuçta ortaya çıkan prototip zinciri
     test [bir Bar sınıfı nesnesi]
         Bar.prototype [bir Foo sınıfı nesnesi] 
-            { foo: 'Hello World' }
+            { foo: 'Hello World', value: 42 }
             Foo.prototype
                 { method: ... }
                 Object.prototype

--- a/doc/zh/object/prototype.md
+++ b/doc/zh/object/prototype.md
@@ -35,7 +35,7 @@ other way around is a far more difficult task.)
     // 原型链
     test [Bar的实例]
         Bar.prototype [Foo的实例] 
-            { foo: 'Hello World' }
+            { foo: 'Hello World', value: 42 }
             Foo.prototype
                 {method: ...};
                 Object.prototype

--- a/doc/zhtw/object/prototype.md
+++ b/doc/zhtw/object/prototype.md
@@ -33,7 +33,7 @@ JavaScript 不包含傳統繼承的模型，它使用的是*原型*模型。
     // 原型鏈
     test [instance of Bar]
         Bar.prototype [instance of Foo]
-            { foo: 'Hello World' }
+            { foo: 'Hello World', value: 42 }
             Foo.prototype
                 { method: ... }
                 Object.prototype


### PR DESCRIPTION
Noticed a minor fix in the prototype sample output. Basically the 'value' property of 'foo' instance wasn't demonstrated in the prototype chain.

Have added it now and updated for all languages.