### PR TITLE
Added semicola to function expressions

### DIFF
--- a/doc/en/function/this.md
+++ b/doc/en/function/this.md
@@ -63,7 +63,7 @@ mis-design of the language because it **never** has any practical use.
             // this is set to the global object
         }
         test();
-    }
+    };
 
 A common misconception is that `this` inside of `test` refers to `Foo`; while in
 fact, it **does not**.
@@ -77,7 +77,7 @@ local variable inside of `method` that refers to `Foo`.
             // Use self instead of this here
         }
         test();
-    }
+    };
 
 `self` is just a normal variable name, but it is commonly used for the reference to an
 outer `this`. In combination with [closures](#function.closures), it can also 
@@ -90,7 +90,7 @@ As of ECMAScript 5 you can use the `bind` method combined with an anonymous func
             // this now refers to Foo
         }.bind(this);
         test();
-    }
+    };
 
 ### Assigning Methods
 


### PR DESCRIPTION
As of above, function expressions should be ended with `;`