### PR TITLE
Minor translation Fix.

### DIFF
--- a/doc/es/object/general.md
+++ b/doc/es/object/general.md
@@ -91,7 +91,7 @@ Las propiedades de los objetos puede ser simbolizados como caracteres planos y c
 a otro mal diseño del parser de JavaScript, lo anterior es una excepción
 de `SyntaxError` antes de ECMAScript 5.
 
-Este error se debe al `eliminar` una *keyword*; por lo tanto, debe ser
+Este error se produce porque `delete` es una *keyword*; por lo tanto, debe ser
 anotado como un *string literal* para asegurarse que será interpretado correctamente
 por diversos motores de JavaScript.
 


### PR DESCRIPTION
This edit solves the Issue: ES translation issue in "Notation of Keys" section. #361 (https://github.com/BonsaiDen/JavaScript-Garden/issues/361)

Original Issue Text:ES translation issue in "Notation of Keys" section. #361

There is a translation error (into Spanish) in the "Notation of Keys" section of the "JavaScript Garden", just before "The prototype" section.

The original English text reads:
"This error arises from the fact that delete is a keyword;"
And the translation reads:
"Este error se debe al eliminar una keyword;" that means "The error is due to deleting a keyword". Also it translates a language keyword, and that I think is wrong.

A better translation might be (just a suggestion):
"Este error se produce porque delete es una palabra clave;"

Thanks for your time and al the great work put into the garden... It's green and beautiful.