### PR TITLE
Objects: Loose the quotes in square bracket example

### DIFF
--- a/doc/en/object/general.md
+++ b/doc/en/object/general.md
@@ -50,7 +50,7 @@ notation or the square bracket notation.
     foo[get]; // kitten
     
     foo.1234; // SyntaxError
-    foo['1234']; // works
+    foo[1234]; // works
 
 The notations work almost identically, with the only difference being that the
 square bracket notation allows for dynamic setting of properties and


### PR DESCRIPTION
Under Accessing properties under [Objects](http://bonsaiden.github.io/JavaScript-Garden/#object.general), the text says: 

> square bracket notation allows for dynamic setting of properties and
the use of property names that would otherwise lead to a syntax error.

Hence a better example for it would be with the same key instead of a string.

```diff
foo.1234; // SyntaxError

- foo['1234']; // works
+ foo[1234]; // works
```
 
Let me know if that's correct and I'll update files for other languages as well 😄 
