### PR TITLE
Fix missing spaces in the footer

### DIFF
--- a/garden.jade
+++ b/garden.jade
@@ -79,10 +79,10 @@ html(lang=language)
     footer
       p Copyright &copy;. Built with
         |
-        a(href='http://nodejs.org/') Node.js
-        | using a
-        a(href='https://github.com/visionmedia/jade/') jade
-        | template.
+        a(href='http://nodejs.org/')  Node.js
+        |  using a
+        a(href='https://github.com/visionmedia/jade/')  jade
+        |  template.
 
     script(src='//ajax.googleapis.com/ajax/libs/jquery/1.5.1/jquery.min.js')
 


### PR DESCRIPTION
The actual footer of the website miss spaces, some words are glued together:

> Copyright ©. Built with |Node.jsusing ajadetemplate.

I just added some spaces to fix this mistake and get a nice footer:

> Copyright ©. Built with | Node.js using a jade template.